### PR TITLE
Add data_ingest Go module with websocket ingestion

### DIFF
--- a/data_ingest/Dockerfile
+++ b/data_ingest/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.20-alpine
+WORKDIR /app
+COPY . .
+RUN go build -o /app/data_ingest
+CMD ["/app/data_ingest"]

--- a/data_ingest/go.mod
+++ b/data_ingest/go.mod
@@ -1,0 +1,10 @@
+module github.com/you/prof-scalper-bot/data_ingest
+
+go 1.24.3
+
+require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/redis/go-redis/v9 v9.11.0 // indirect
+)

--- a/data_ingest/go.sum
+++ b/data_ingest/go.sum
@@ -1,0 +1,8 @@
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/redis/go-redis/v9 v9.11.0 h1:E3S08Gl/nJNn5vkxd2i78wZxWAPNZgUNTp8WIJUAiIs=
+github.com/redis/go-redis/v9 v9.11.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=

--- a/data_ingest/main.go
+++ b/data_ingest/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/redis/go-redis/v9"
+)
+
+// Publisher interface allows publishing messages to a channel
+// This abstraction enables testing without a real Redis server.
+type Publisher interface {
+	Publish(ctx context.Context, channel string, message interface{}) error
+}
+
+// redisPublisher implements Publisher using go-redis.
+type redisPublisher struct {
+	client *redis.Client
+}
+
+func (r *redisPublisher) Publish(ctx context.Context, channel string, message interface{}) error {
+	return r.client.Publish(ctx, channel, message).Err()
+}
+
+func newRedisPublisher() Publisher {
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		addr = "localhost:6379"
+	}
+	rdb := redis.NewClient(&redis.Options{Addr: addr})
+	return &redisPublisher{client: rdb}
+}
+
+// runClient connects to the websocket url, sends subscription messages and
+// forwards all incoming messages to the Publisher on channel "ticks".
+func runClient(ctx context.Context, url string, subs []string, pub Publisher) error {
+	c, _, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	for _, s := range subs {
+		if err := c.WriteMessage(websocket.TextMessage, []byte(s)); err != nil {
+			return err
+		}
+	}
+
+	for {
+		_, msg, err := c.ReadMessage()
+		if err != nil {
+			return err
+		}
+		if err := pub.Publish(ctx, "ticks", msg); err != nil {
+			log.Println("publish error:", err)
+		}
+	}
+}
+
+func main() {
+	pub := newRedisPublisher()
+	ctx := context.Background()
+
+	binanceURL := os.Getenv("BINANCE_WS")
+	if binanceURL == "" {
+		binanceURL = "wss://stream.binance.com:9443/ws/btcusdt@trade"
+	}
+	bybitURL := os.Getenv("BYBIT_WS")
+	if bybitURL == "" {
+		bybitURL = "wss://stream.bybit.com/v5/public/spot"
+	}
+
+	go func() {
+		subs := []string{"{\"op\":\"subscribe\",\"args\":[\"trade.BTCUSDT\",\"orderbook.1.BTCUSDT\"]}"}
+		if err := runClient(ctx, bybitURL, subs, pub); err != nil {
+			log.Println("bybit error:", err)
+		}
+	}()
+
+	subs := []string{"{\"method\":\"SUBSCRIBE\",\"params\":[\"btcusdt@trade\",\"btcusdt@depth@100ms\"],\"id\":1}"}
+	if err := runClient(ctx, binanceURL, subs, pub); err != nil {
+		log.Println("binance error:", err)
+	}
+
+	// keep running
+	for {
+		time.Sleep(time.Minute)
+	}
+}

--- a/data_ingest/tick_test.go
+++ b/data_ingest/tick_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// mockPublisher records published messages for assertions.
+type mockPublisher struct {
+	msgs []string
+}
+
+func (m *mockPublisher) Publish(ctx context.Context, channel string, message interface{}) error {
+	switch v := message.(type) {
+	case string:
+		m.msgs = append(m.msgs, v)
+	case []byte:
+		m.msgs = append(m.msgs, string(v))
+	default:
+		return nil
+	}
+	return nil
+}
+
+func startWSServer(t *testing.T, messages []string) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, msg := range messages {
+			if err := c.WriteMessage(websocket.TextMessage, []byte(msg)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}))
+	return server
+}
+
+func TestRunClientPublishesTicks(t *testing.T) {
+	msgs := []string{`{"type":"trade"}`, `{"type":"depth"}`}
+	srv := startWSServer(t, msgs)
+	defer srv.Close()
+
+	wsURL := "ws" + srv.URL[4:]
+	mp := &mockPublisher{}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	go runClient(ctx, wsURL, nil, mp)
+	time.Sleep(200 * time.Millisecond)
+
+	if len(mp.msgs) != len(msgs) {
+		t.Fatalf("expected %d messages, got %d", len(msgs), len(mp.msgs))
+	}
+	for i, m := range msgs {
+		if mp.msgs[i] != m {
+			t.Errorf("message %d mismatch: got %s want %s", i, mp.msgs[i], m)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add data_ingest go module with websocket clients for Binance and Bybit
- forward ticks into Redis pub/sub channel
- include Dockerfile for building the binary
- unit test websocket ingestion and Redis publish logic

## Testing
- `go test -run TestRunClientPublishesTicks -v`

------
https://chatgpt.com/codex/tasks/task_e_6874d02f44cc832aa4bd854d611db862