### PR TITLE
Add feature_store module with PCA job

### DIFF
--- a/feature_store/client.py
+++ b/feature_store/client.py
@@ -1,0 +1,15 @@
+import os
+import redis
+import psycopg2
+
+
+def get_redis() -> redis.Redis:
+    """Return a Redis connection using REDIS_URL env var."""
+    url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    return redis.Redis.from_url(url)
+
+
+def get_postgres() -> psycopg2.extensions.connection:
+    """Return a PostgreSQL connection using TIMESCALE_URL env var."""
+    dsn = os.getenv("TIMESCALE_URL", "dbname=postgres user=postgres host=localhost")
+    return psycopg2.connect(dsn)

--- a/feature_store/migrations/001_create_tables.sql
+++ b/feature_store/migrations/001_create_tables.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS features (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    data JSONB NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS pca_transforms (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    components JSONB NOT NULL
+);

--- a/feature_store/pca.py
+++ b/feature_store/pca.py
@@ -1,0 +1,54 @@
+import json
+import pandas as pd
+from sklearn.decomposition import PCA
+from sklearn.preprocessing import StandardScaler
+
+from . import client
+
+
+def load_features(conn) -> pd.DataFrame:
+    """Load all feature rows from the database and return a DataFrame."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT data FROM features")
+        rows = cur.fetchall()
+    records = [row[0] for row in rows]
+    return pd.DataFrame(records)
+
+
+def compute_pca(df: pd.DataFrame) -> dict:
+    """Compute PCA on dataframe after standardizing."""
+    scaler = StandardScaler()
+    scaled = scaler.fit_transform(df)
+    pca = PCA()
+    pca.fit(scaled)
+
+    # Determine components with at least 1% variance
+    indices = [i for i, var in enumerate(pca.explained_variance_ratio_) if var >= 0.01]
+    n_components = max(indices) + 1 if indices else 1
+
+    pca = PCA(n_components=n_components)
+    pca.fit(scaled)
+
+    return {
+        "components": pca.components_.tolist(),
+        "mean": scaler.mean_.tolist(),
+        "scale": scaler.scale_.tolist(),
+        "explained_variance_ratio": pca.explained_variance_ratio_.tolist(),
+    }
+
+
+def run():
+    """Run the daily PCA job and store params in Redis."""
+    pg = client.get_postgres()
+    df = load_features(pg)
+    params = compute_pca(df)
+
+    r = client.get_redis()
+    r.set("pca:params", json.dumps(params))
+
+    pg.close()
+    return params
+
+
+if __name__ == "__main__":
+    run()

--- a/feature_store/tests/test_pca.py
+++ b/feature_store/tests/test_pca.py
@@ -1,0 +1,34 @@
+import json
+from unittest import mock
+
+import pandas as pd
+
+from feature_store import pca
+
+
+class DummyRedis(dict):
+    def set(self, key, value):
+        self[key] = value
+
+
+def test_compute_pca_and_store():
+    data = pd.DataFrame({
+        'a': [1, 2, 3, 4, 5],
+        'b': [2, 3, 4, 5, 6],
+        'c': [10, 10, 10, 10, 10],
+    })
+
+    with mock.patch('feature_store.pca.client.get_postgres') as get_pg, \
+            mock.patch('feature_store.pca.client.get_redis') as get_redis:
+        get_pg.return_value.cursor.return_value.__enter__.return_value.fetchall.return_value = [
+            ({'a': int(row.a), 'b': int(row.b), 'c': int(row.c)},) for row in data.itertuples()
+        ]
+        get_redis.return_value = DummyRedis()
+
+        params = pca.run()
+        stored = get_redis.return_value['pca:params']
+        loaded = json.loads(stored)
+
+        assert 'components' in loaded
+        for ratio in loaded['explained_variance_ratio']:
+            assert ratio >= 0.01

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+numpy
+scikit-learn
+psycopg2-binary
+redis


### PR DESCRIPTION
## Summary
- implement `feature_store` package
- connect to Redis and TimescaleDB via `client.py`
- add SQL migrations for `features` and `pca_transforms`
- implement PCA daily job and serialization
- provide requirements and unit tests

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874d04dc694832aab063ca44423a2b4