### PR TITLE
Add allocator and risk engine modules

### DIFF
--- a/allocator.py
+++ b/allocator.py
@@ -1,0 +1,72 @@
+import argparse
+import cvxpy as cp
+import numpy as np
+import pandas as pd
+
+
+def optimize_portfolio(confidence: pd.Series, cov: pd.DataFrame, cvar_limit: float = 0.05, alpha: float = 0.95) -> pd.Series:
+    """Optimize portfolio weights with CVaR constraint.
+
+    Parameters
+    ----------
+    confidence : pd.Series
+        Expected returns for each asset.
+    cov : pd.DataFrame
+        Covariance matrix of asset returns.
+    cvar_limit : float, optional
+        Maximum allowed CVaR, by default 0.05.
+    alpha : float, optional
+        Confidence level for CVaR, by default 0.95.
+
+    Returns
+    -------
+    pd.Series
+        Optimized portfolio weights indexed by asset.
+    """
+    assets = confidence.index
+    n = len(assets)
+    mu = confidence.values
+    sigma = cov.values
+
+    w = cp.Variable(n)
+
+    # simulate scenarios assuming multivariate normal returns
+    np.random.seed(42)
+    scenarios = np.random.multivariate_normal(mu, sigma, size=500)
+    portfolio_returns = scenarios @ w
+
+    t = cp.Variable()
+    u = cp.Variable(500)
+
+    cvar = t + cp.sum(u) / (500 * (1 - alpha))
+
+    constraints = [
+        cp.sum(w) == 1,
+        w >= 0,
+        u >= 0,
+        u >= -portfolio_returns - t,
+        cvar <= cvar_limit,
+    ]
+
+    problem = cp.Problem(cp.Maximize(mu @ w), constraints)
+    problem.solve()
+
+    return pd.Series(w.value, index=assets)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Optimize portfolio weights with CVaR constraint")
+    parser.add_argument("--conf", required=True, help="CSV file of expected returns")
+    parser.add_argument("--cov", required=True, help="CSV file of covariance matrix")
+    parser.add_argument("--out", required=True, help="Output CSV for weights")
+    args = parser.parse_args()
+
+    conf = pd.read_csv(args.conf, index_col=0, squeeze=True)
+    cov = pd.read_csv(args.cov, index_col=0)
+
+    weights = optimize_portfolio(conf, cov)
+    weights.to_csv(args.out, header=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/risk_engine.py
+++ b/risk_engine.py
@@ -1,0 +1,87 @@
+import json
+import threading
+import time
+from collections import deque
+from typing import Optional
+
+import numpy as np
+import requests
+from flask import Flask, Response
+from kafka import KafkaConsumer
+
+
+class RiskEngine:
+    def __init__(self, kafka_servers: Optional[str] = "localhost:9092", pagerduty_url: Optional[str] = None,
+                 var_threshold: float = 1.0, es_threshold: float = 1.0, consumer: Optional[KafkaConsumer] = None):
+        if consumer is None and kafka_servers is not None:
+            self.consumer = KafkaConsumer(
+                'trades', 'positions',
+                bootstrap_servers=kafka_servers,
+                value_deserializer=lambda m: json.loads(m.decode('utf-8')),
+                auto_offset_reset='latest',
+                enable_auto_commit=True
+            )
+        else:
+            self.consumer = consumer
+        self.pagerduty_url = pagerduty_url
+        self.var_threshold = var_threshold
+        self.es_threshold = es_threshold
+        self.pnl_history = deque(maxlen=1000)
+        self.app = Flask(__name__)
+        self.app.add_url_rule('/metrics', 'metrics', self.metrics)
+        self.app.add_url_rule('/health', 'health', self.health)
+
+    def handle_message(self, data: dict):
+        if 'pnl' in data:
+            self.pnl_history.append(float(data['pnl']))
+
+    def compute_risk(self):
+        if not self.pnl_history:
+            return 0.0, 0.0
+        losses = -np.array(self.pnl_history)
+        var = float(np.quantile(losses, 0.95))
+        es = float(losses[losses >= var].mean())
+        return var, es
+
+    def check_thresholds(self):
+        var, es = self.compute_risk()
+        if (var > self.var_threshold or es > self.es_threshold) and self.pagerduty_url:
+            try:
+                requests.post(self.pagerduty_url, json={'var': var, 'es': es})
+            except Exception:
+                pass
+
+    def metrics(self):
+        var, es = self.compute_risk()
+        metrics = f"# HELP portfolio_var Value at Risk\n" \
+                  f"# TYPE portfolio_var gauge\nportfolio_var {var}\n" \
+                  f"# HELP portfolio_es Expected Shortfall\n" \
+                  f"# TYPE portfolio_es gauge\nportfolio_es {es}\n"
+        return Response(metrics, mimetype='text/plain')
+
+    def health(self):
+        return 'ok'
+
+    def start(self, port: int = 8000):
+        if self.consumer is not None:
+            def consume_loop():
+                for msg in self.consumer:
+                    self.handle_message(msg.value)
+            threading.Thread(target=consume_loop, daemon=True).start()
+
+        def risk_loop():
+            while True:
+                time.sleep(60)
+                self.check_thresholds()
+        threading.Thread(target=risk_loop, daemon=True).start()
+
+        self.app.run(host='0.0.0.0', port=port)
+
+
+def main():
+    engine = RiskEngine()
+    engine.start()
+
+
+if __name__ == '__main__':
+    main()

--- a/risk_engine/tests/test_risk.py
+++ b/risk_engine/tests/test_risk.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.insert(0, ROOT)
+import risk_engine
+
+
+def test_risk_metrics():
+    engine = risk_engine.RiskEngine(kafka_servers=None, consumer=None, pagerduty_url=None)
+    for pnl in [0.1, -0.2, 0.3, -0.1, 0.05]:
+        engine.handle_message({'pnl': pnl})
+    var, es = engine.compute_risk()
+    assert var > 0
+    assert es > 0
+
+
+def test_pagerduty_called(monkeypatch):
+    calls = []
+
+    def fake_post(url, json):
+        calls.append((url, json))
+        class Resp:
+            status_code = 200
+        return Resp()
+
+    monkeypatch.setattr(risk_engine.requests, 'post', fake_post)
+    engine = risk_engine.RiskEngine(kafka_servers=None, consumer=None, pagerduty_url='http://pager', var_threshold=0.0, es_threshold=0.0)
+    engine.handle_message({'pnl': -1.0})
+    engine.check_thresholds()
+    assert calls
+


### PR DESCRIPTION
## Summary
- implement `allocator.py` with CVaR-constrained optimizer and CLI
- implement `risk_engine.py` providing risk metrics, alerting, and HTTP endpoints
- add pytest suite for risk engine logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874d0c391e0832a8f67141925f15025