### PR TITLE
Add monitoring configs

### DIFF
--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -1,0 +1,8 @@
+route:
+  receiver: pagerduty
+
+receivers:
+  - name: pagerduty
+    pagerduty_configs:
+      - routing_key: ${PAGERDUTY_KEY}
+        send_resolved: true

--- a/monitoring/grafana/data_ingest_latency.json
+++ b/monitoring/grafana/data_ingest_latency.json
@@ -1,0 +1,12 @@
+{
+  "title": "Data Ingest Latency",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Latency",
+      "targets": [
+        {"expr": "data_ingest_latency_seconds"}
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/order_gateway_latency.json
+++ b/monitoring/grafana/order_gateway_latency.json
@@ -1,0 +1,12 @@
+{
+  "title": "Order Gateway Latency",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Latency",
+      "targets": [
+        {"expr": "order_gateway_latency_seconds"}
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/risk_engine_latency.json
+++ b/monitoring/grafana/risk_engine_latency.json
@@ -1,0 +1,12 @@
+{
+  "title": "Risk Engine Latency",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Latency",
+      "targets": [
+        {"expr": "risk_engine_latency_seconds"}
+      ]
+    }
+  ]
+}

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'services'
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - data_ingest:8000
+          - risk_engine:8000
+          - order_gateway:8000


### PR DESCRIPTION
## Summary
- add Prometheus config scraping services
- configure Alertmanager with PagerDuty routing
- add Grafana dashboard JSON files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874d12df3fc832aa08cee64c5349660