### PR TITLE
Fix TensorFlow image loader deprecation

### DIFF
--- a/model_server/requirements.txt
+++ b/model_server/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn
 grpcio
-tensorflow==2.18.0
-tensorflow-serving-api==2.18.0
+tensorflow==2.19.0
+tensorflow-serving-api==2.19.0
 httpx

--- a/models/train.py
+++ b/models/train.py
@@ -46,7 +46,9 @@ def train_lightgbm(X: pd.DataFrame, y: pd.Series):
 def load_images(image_dir: str):
     import tensorflow as tf
 
-    train_ds = tf.keras.preprocessing.image_dataset_from_directory(
+    # `tf.keras.preprocessing.image_dataset_from_directory` is deprecated in
+    # recent TensorFlow versions. Use the utils variant to avoid warnings.
+    train_ds = tf.keras.utils.image_dataset_from_directory(
         image_dir,
         labels="inferred",
         image_size=(64, 64),
@@ -55,7 +57,7 @@ def load_images(image_dir: str):
         subset="training",
         seed=42,
     )
-    val_ds = tf.keras.preprocessing.image_dataset_from_directory(
+    val_ds = tf.keras.utils.image_dataset_from_directory(
         image_dir,
         labels="inferred",
         image_size=(64, 64),

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ requests
 fastapi
 uvicorn
 grpcio
-tensorflow==2.18.0
-tensorflow-serving-api==2.18.0
+tensorflow==2.19.0
+tensorflow-serving-api==2.19.0
 httpx
 flask
 kafka-python


### PR DESCRIPTION
## Summary
- avoid `tf.keras.preprocessing.image_dataset_from_directory` deprecation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68769d7b6e6c832a90e6bb25ff073c23