### PR TITLE
Pin FastAPI stack versions

### DIFF
--- a/model_server/requirements.txt
+++ b/model_server/requirements.txt
@@ -1,6 +1,6 @@
-fastapi
-uvicorn
+fastapi==0.116.1
+uvicorn==0.35.0
 grpcio
 tensorflow==2.19.0
 tensorflow-serving-api==2.19.0
-httpx
+httpx==0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@ scikit-learn
 psycopg2-binary
 redis
 requests
-fastapi
-uvicorn
+fastapi==0.116.1
+uvicorn==0.35.0
 grpcio
 tensorflow==2.19.0
 tensorflow-serving-api==2.19.0
-httpx
+httpx==0.28.1
 flask
 kafka-python


### PR DESCRIPTION
## Summary
- pin versions for FastAPI, Uvicorn and HTTPX across requirements
- run `pytest` to ensure tests pass

## Testing
- `pip install -q -r requirements.txt -r model_server/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687795401770832a8e0e0f1a455f438b